### PR TITLE
Refactor video stream server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ version = "0.1.0"
 dependencies = [
  "color-eyre",
  "concread",
+ "crossbeam",
  "ctrlc",
  "derive_more",
  "dssim",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "mockito",
  "pretty_env_logger",
  "prometheus",
+ "rand 0.8.3",
  "serde_json",
  "sn_fake_clock",
  "structopt",

--- a/hawkeye-core/src/models.rs
+++ b/hawkeye-core/src/models.rs
@@ -117,10 +117,6 @@ impl PartialEq for FakeAction {
     fn eq(&self, _other: &Self) -> bool {
         true
     }
-
-    fn ne(&self, _other: &Self) -> bool {
-        true
-    }
 }
 
 // #[cfg(test)]

--- a/hawkeye-worker/Cargo.toml
+++ b/hawkeye-worker/Cargo.toml
@@ -30,6 +30,7 @@ lazy_static = "1.4.0"
 tokio = { version = "0.2", features = ["full"] }
 warp = "0.2"
 concread = "0.2.1"
+crossbeam = "0.8.0"
 
 [dev-dependencies]
 sn_fake_clock = "0.4"

--- a/hawkeye-worker/Cargo.toml
+++ b/hawkeye-worker/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "0.2", features = ["full"] }
 warp = "0.2"
 concread = "0.2.1"
 crossbeam = "0.8.0"
+rand = "0.8"
 
 [dev-dependencies]
 sn_fake_clock = "0.4"

--- a/hawkeye-worker/src/actions.rs
+++ b/hawkeye-worker/src/actions.rs
@@ -209,12 +209,12 @@ fn try_call(call: &HttpCall) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crossbeam::channel::unbounded;
     use hawkeye_core::models::{FakeAction, HttpMethod};
     use mockito::{mock, server_url, Matcher};
     use sn_fake_clock::FakeClock;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc::channel;
     use std::sync::Arc;
 
     fn sleep(d: Duration) {
@@ -329,7 +329,7 @@ mod tests {
         executor.execute(VideoMode::Content);
         assert_eq!(called.load(Ordering::SeqCst), false);
 
-        let (s, r) = channel();
+        let (s, r) = unbounded();
         // Pile up some events for the runtime to consume
         s.send(Event::Mode(VideoMode::Slate)).unwrap();
         s.send(Event::Terminate).unwrap();

--- a/hawkeye-worker/src/actions.rs
+++ b/hawkeye-worker/src/actions.rs
@@ -4,9 +4,9 @@ use crate::metrics::{
 };
 use crate::video_stream::Event;
 use color_eyre::Result;
+use crossbeam::channel::Receiver;
 use hawkeye_core::models::{self, Action, HttpAuth, HttpCall, VideoMode};
 use log::{debug, error, info, warn};
-use std::sync::mpsc::Receiver;
 use std::time::Duration;
 
 #[cfg(test)]

--- a/hawkeye-worker/src/img_detector.rs
+++ b/hawkeye-worker/src/img_detector.rs
@@ -2,7 +2,6 @@ use color_eyre::Result;
 use dssim::{DssimImage, ToRGBAPLU, RGBAPLU};
 use imgref::{Img, ImgVec};
 use load_image::{Image, ImageData};
-use std::io::Read;
 
 pub struct SlateDetector {
     slate: DssimImage<f32>,
@@ -10,11 +9,9 @@ pub struct SlateDetector {
 }
 
 impl SlateDetector {
-    pub fn new<R: Read>(slate: &mut R) -> Result<Self> {
-        let mut buffer = Vec::new();
-        slate.read_to_end(&mut buffer).unwrap();
+    pub fn new(slate: &[u8]) -> Result<Self> {
         let similarity_algorithm = dssim::Dssim::new();
-        let slate_img = load_data(buffer.as_slice())?;
+        let slate_img = load_data(slate)?;
         let slate = similarity_algorithm.create_image(&slate_img).unwrap();
 
         Ok(Self {

--- a/hawkeye-worker/src/img_detector.rs
+++ b/hawkeye-worker/src/img_detector.rs
@@ -5,8 +5,6 @@ use load_image::{Image, ImageData};
 use std::io::Read;
 
 pub struct SlateDetector {
-    width: usize,
-    height: usize,
     slate: DssimImage<f32>,
     similarity_algorithm: dssim::Dssim,
 }
@@ -20,8 +18,6 @@ impl SlateDetector {
         let slate = similarity_algorithm.create_image(&slate_img).unwrap();
 
         Ok(Self {
-            width: slate_img.width(),
-            height: slate_img.height(),
             slate,
             similarity_algorithm,
         })
@@ -36,10 +32,6 @@ impl SlateDetector {
         let val = (val * 1000f64) as u32;
 
         val <= 900u32
-    }
-
-    pub fn required_image_size(&self) -> (usize, usize) {
-        (self.width, self.height)
     }
 }
 

--- a/hawkeye-worker/src/img_detector.rs
+++ b/hawkeye-worker/src/img_detector.rs
@@ -69,7 +69,11 @@ mod test {
     fn compare_equal_images() {
         let mut slate =
             File::open("../resources/slate_120px.jpg").expect("Missing file in resources folder");
-        let detector = SlateDetector::new(&mut slate).unwrap();
+        let mut buffer = Vec::new();
+        slate
+            .read_to_end(&mut buffer)
+            .expect("Failed to write to buffer");
+        let detector = SlateDetector::new(buffer.as_slice()).unwrap();
         let slate_img = read_bytes("../resources/slate_120px.jpg");
 
         assert!(detector.is_match(slate_img.as_slice()));
@@ -79,7 +83,11 @@ mod test {
     fn compare_diff_images() {
         let mut slate =
             File::open("../resources/slate_120px.jpg").expect("Missing file in resources folder");
-        let detector = SlateDetector::new(&mut slate).unwrap();
+        let mut buffer = Vec::new();
+        slate
+            .read_to_end(&mut buffer)
+            .expect("Failed to write to buffer");
+        let detector = SlateDetector::new(buffer.as_slice()).unwrap();
         let frame_img = read_bytes("../resources/non-slate_120px.jpg");
 
         assert_eq!(detector.is_match(frame_img.as_slice()), false);

--- a/hawkeye-worker/src/main.rs
+++ b/hawkeye-worker/src/main.rs
@@ -11,13 +11,13 @@ use crate::img_detector::SlateDetector;
 use crate::metrics::run_metrics_service;
 use crate::video_stream::{process_frames, RtpServer};
 use color_eyre::Result;
+use crossbeam::channel::unbounded;
 use gstreamer as gst;
 use hawkeye_core::models::Watcher;
 use log::info;
 use pretty_env_logger::env_logger;
 use std::fs::File;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
 use structopt::StructOpt;
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
     info!("Initializing GStreamer..");
     gst::init().expect("Could not initialize GStreamer!");
 
-    let (sender, receiver) = channel();
+    let (sender, receiver) = unbounded();
 
     info!("Loading executors..");
     let mut executors: Vec<ActionExecutor> = Vec::new();
@@ -79,5 +79,5 @@ fn main() -> Result<()> {
         watcher.source.codec,
     );
 
-    process_frames(server, detector, running, sender)
+    process_frames(server.into_iter(), detector, running, sender)
 }

--- a/hawkeye-worker/src/main.rs
+++ b/hawkeye-worker/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
     })
     .expect("Error setting termination handler");
 
-    let detector = SlateDetector::new(&mut slate::load_img(watcher.slate_url.as_str())?)?;
+    let detector = SlateDetector::new(&slate::load_img(watcher.slate_url.as_str())?)?;
     log::info!(
         "Starting pipeline at rtp://0.0.0.0:{}",
         watcher.source.ingest_port

--- a/hawkeye-worker/src/metrics.rs
+++ b/hawkeye-worker/src/metrics.rs
@@ -25,6 +25,16 @@ lazy_static! {
         "Number of times we searched for slate in the stream"
     )
     .unwrap();
+    pub static ref SIMILARITY_EXECUTION_DURATION: Histogram = register_histogram!(
+        "similarity_execution_seconds",
+        "Seconds it took to execute the similarity algorithm"
+    )
+    .unwrap();
+    pub static ref FRAME_PROCESSING_DURATION: Histogram = register_histogram!(
+        "frame_processing_seconds",
+        "Seconds it took to execute the whole frame processing block"
+    )
+    .unwrap();
     pub static ref HTTP_CALL_DURATION: Histogram = register_histogram!(
         "http_call_action_execution_seconds",
         "Seconds it took to execute the HTTP call"

--- a/hawkeye-worker/src/slate.rs
+++ b/hawkeye-worker/src/slate.rs
@@ -25,11 +25,11 @@ pub fn load_img(url: &str) -> Result<Box<dyn Read>> {
         let path = temp_file.full_path();
         debug!("Loading slate image from file: {}", path);
         let img = image::open(path.as_str())
-            .wrap_err("Could not open image")?
+            .wrap_err("Failed to open image")?
             .resize_exact(SLATE_SIZE.0, SLATE_SIZE.1, FilterType::Triangle);
         let mut contents = Vec::new();
         img.write_to(&mut contents, ImageFormat::Png)
-            .wrap_err("Could not write to temp file")?;
+            .wrap_err("Failed to write to temp file")?;
         contents
     };
 
@@ -87,14 +87,14 @@ impl TempFile {
     pub fn new<S: AsRef<str>, T: AsRef<str>>(name: S, ext: T) -> Result<Self> {
         let path = Self::file_path(name.as_ref(), ext.as_ref());
         Ok(Self {
-            file: File::create(path.as_str()).wrap_err("Could not create temp file")?,
+            file: File::create(path.as_str()).wrap_err("Failed to create temp file")?,
             path,
         })
     }
 
     pub fn from_original<S: AsRef<str>>(full_path: S) -> Result<Self> {
         Ok(Self {
-            file: File::open(full_path.as_ref()).wrap_err("Could not open provided path")?,
+            file: File::open(full_path.as_ref()).wrap_err("Failed open provided path")?,
             path: String::from(full_path.as_ref()),
         })
     }

--- a/hawkeye-worker/src/slate.rs
+++ b/hawkeye-worker/src/slate.rs
@@ -49,7 +49,7 @@ pub trait FileLike {
         Ok(String::from(
             Path::new(self.full_path().as_str())
                 .extension()
-                .ok_or(color_eyre::eyre::eyre!("File does not have extension"))?
+                .ok_or_else(|| color_eyre::eyre::eyre!("File does not have extension"))?
                 .to_str()
                 .unwrap(),
         ))
@@ -102,14 +102,14 @@ impl TempFile {
     fn is_video(&self) -> bool {
         VIDEO_FILE_EXTENSIONS
             .iter()
-            .any(|v| v.to_string() == self.extension().unwrap_or_else(|_| String::new()))
+            .any(|v| *v == self.extension().unwrap_or_else(|_| String::new()))
     }
 
     fn write_all<R: Read>(&mut self, mut reader: R) -> Result<()> {
         let mut buffer = Vec::with_capacity(5 * MEGABYTES);
         loop {
             let p = reader.read_to_end(&mut buffer)?;
-            self.file.write(buffer.as_slice())?;
+            self.file.write_all(buffer.as_slice())?;
             buffer.clear();
             if p == 0 {
                 break;

--- a/hawkeye-worker/src/slate.rs
+++ b/hawkeye-worker/src/slate.rs
@@ -4,11 +4,12 @@ use color_eyre::Result;
 use image::imageops::FilterType;
 use image::ImageFormat;
 use log::debug;
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
 use std::convert::{TryFrom, TryInto};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
-use std::process;
 use std::time::Duration;
 
 pub const SLATE_SIZE: (u32, u32) = (213, 120);
@@ -119,7 +120,12 @@ impl TempFile {
     }
 
     fn file_path(name: &str, ext: &str) -> String {
-        format!("/tmp/hwk_{}_{}.{}", process::id(), name, ext)
+        let rand_string: String = thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(10)
+            .map(char::from)
+            .collect();
+        format!("/tmp/hwk_{}_{}.{}", rand_string, name, ext)
     }
 }
 

--- a/hawkeye-worker/src/slate.rs
+++ b/hawkeye-worker/src/slate.rs
@@ -176,7 +176,10 @@ impl FrameCapture {
             self.frame_size.1
         );
         for frame in VideoStream::new(pipeline) {
-            return Ok(frame?);
+            match frame? {
+                Some(contents) => return Ok(contents),
+                None => continue,
+            }
         }
         Err(color_eyre::eyre::eyre!("Failed to capture video frame"))
     }

--- a/hawkeye-worker/src/slate.rs
+++ b/hawkeye-worker/src/slate.rs
@@ -6,7 +6,7 @@ use image::ImageFormat;
 use log::debug;
 use std::convert::{TryFrom, TryInto};
 use std::fs::File;
-use std::io::{Cursor, Read, Write};
+use std::io::{Read, Write};
 use std::path::Path;
 use std::process;
 use std::time::Duration;
@@ -15,7 +15,7 @@ pub const SLATE_SIZE: (u32, u32) = (213, 120);
 const MEGABYTES: usize = 1024 * 1024;
 const VIDEO_FILE_EXTENSIONS: [&str; 2] = ["mp4", "mkv"];
 
-pub fn load_img(url: &str) -> Result<Box<dyn Read>> {
+pub fn load_img(url: &str) -> Result<Vec<u8>> {
     let temp_file: TempFile = Url::new(url).try_into()?;
 
     let contents = if temp_file.is_video() {
@@ -39,7 +39,7 @@ pub fn load_img(url: &str) -> Result<Box<dyn Read>> {
         debug!("Wrote to debug file: {}", f.full_path())
     }
 
-    Ok(Box::new(Cursor::new(contents)))
+    Ok(contents)
 }
 
 pub trait FileLike {

--- a/hawkeye-worker/src/video_stream.rs
+++ b/hawkeye-worker/src/video_stream.rs
@@ -1,5 +1,3 @@
-// Based on https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/blob/master/examples/src/bin/thumbnail.rs
-
 use crate::img_detector::SlateDetector;
 use crate::metrics::{
     FOUND_CONTENT_COUNTER, FOUND_SLATE_COUNTER, FRAME_PROCESSING_DURATION,
@@ -58,7 +56,7 @@ pub fn process_frames(
                 log::trace!("Empty iterations: {}", empty_iterations);
                 empty_iterations = 0;
                 contents
-            },
+            }
             None => {
                 if !running.load(Ordering::SeqCst) {
                     break;
@@ -336,7 +334,7 @@ impl Iterator for VideoStreamIterator {
 
 impl Drop for VideoStreamIterator {
     fn drop(&mut self) {
-        if let Err(_) = self.pipeline.set_state(gst::State::Null) {
+        if self.pipeline.set_state(gst::State::Null).is_err() {
             log::error!("Could not stop pipeline");
         }
         log::debug!("Pipeline stopped!");

--- a/hawkeye-worker/src/video_stream.rs
+++ b/hawkeye-worker/src/video_stream.rs
@@ -17,7 +17,6 @@ use gstreamer_app as gst_app;
 use hawkeye_core::models::{Codec, Container, VideoMode};
 use lazy_static::lazy_static;
 use log::{debug, info};
-use std::io::Cursor;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -43,16 +42,15 @@ pub enum Event {
 }
 
 pub fn process_frames(
-    source: impl Iterator<Item = Result<Option<Vec<u8>>>>,
+    frame_source: impl Iterator<Item = Result<Option<Vec<u8>>>>,
     detector: SlateDetector,
     running: Arc<AtomicBool>,
     action_sink: Sender<Event>,
 ) -> Result<()> {
     let black_image = include_bytes!("../../resources/black_120px.jpg");
-    let mut black_image = Cursor::new(black_image.to_vec());
-    let black_detector = SlateDetector::new(&mut black_image)?;
+    let black_detector = SlateDetector::new(black_image)?;
 
-    for frame in source {
+    for frame in frame_source {
         let frame_processing_timer = FRAME_PROCESSING_DURATION.start_timer();
         let local_buffer = match frame? {
             Some(b) => b,


### PR DESCRIPTION
This PR expands the usage of `VideoStream`, a GStreamer pipeline abstraction. for capturing video frames, to implement a `RtpServer` that produces video frames as an iterator. I've removed the duplicated code for setting up the GStreamer pipeline.

The server is more conservative in terms of memory usage by using a bounded message queue (`crossbeam`) that only keeps in memory the most recent video frame.