### PR TITLE
Upgrade watcher worker image when necessary

### DIFF
--- a/hawkeye-api/src/filters.rs
+++ b/hawkeye-api/src/filters.rs
@@ -13,6 +13,7 @@ pub fn v1(
         .or(watcher_create(client.clone()))
         .or(watcher_get(client.clone()))
         .or(watcher_delete(client.clone()))
+        .or(watcher_update(client.clone()))
         .or(watcher_start(client.clone()))
         .or(watcher_stop(client.clone()))
         .or(watcher_video_frame(client.clone()))
@@ -63,6 +64,17 @@ pub fn watcher_delete(
         .and(warp::delete())
         .and(with_client(client))
         .and_then(handlers::delete_watcher)
+}
+
+/// POST /v1/watchers/{id}
+pub fn watcher_update(
+    client: Client,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v1" / "watchers" / String)
+        .and(auth::verify())
+        .and(warp::post())
+        .and(with_client(client))
+        .and_then(handlers::update_watcher)
 }
 
 /// POST /v1/watchers/{id}/start

--- a/hawkeye-api/src/filters.rs
+++ b/hawkeye-api/src/filters.rs
@@ -13,7 +13,7 @@ pub fn v1(
         .or(watcher_create(client.clone()))
         .or(watcher_get(client.clone()))
         .or(watcher_delete(client.clone()))
-        .or(watcher_update(client.clone()))
+        .or(watcher_upgrade(client.clone()))
         .or(watcher_start(client.clone()))
         .or(watcher_stop(client.clone()))
         .or(watcher_video_frame(client.clone()))
@@ -66,15 +66,15 @@ pub fn watcher_delete(
         .and_then(handlers::delete_watcher)
 }
 
-/// POST /v1/watchers/{id}
-pub fn watcher_update(
+/// POST /v1/watchers/{id}/upgrade
+pub fn watcher_upgrade(
     client: Client,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    warp::path!("v1" / "watchers" / String)
+    warp::path!("v1" / "watchers" / String / "upgrade")
         .and(auth::verify())
         .and(warp::post())
         .and(with_client(client))
-        .and_then(handlers::update_watcher)
+        .and_then(handlers::upgrade_watcher)
 }
 
 /// POST /v1/watchers/{id}/start

--- a/hawkeye-api/src/handlers.rs
+++ b/hawkeye-api/src/handlers.rs
@@ -94,8 +94,8 @@ pub async fn create_watcher(
     ))
 }
 
-pub async fn update_watcher(id: String, client: Client) -> Result<impl warp::Reply, Infallible> {
-    log::debug!("v1.update_watcher: {}", id);
+pub async fn upgrade_watcher(id: String, client: Client) -> Result<impl warp::Reply, Infallible> {
+    log::debug!("v1.upgrade_watcher: {}", id);
     let deployments: Api<Deployment> = Api::namespaced(client.clone(), &NAMESPACE);
     let deployment = match deployments.get(&templates::deployment_name(&id)).await {
         Ok(d) => d,

--- a/hawkeye-api/src/handlers.rs
+++ b/hawkeye-api/src/handlers.rs
@@ -1,5 +1,6 @@
 use crate::config::NAMESPACE;
 use crate::templates;
+use crate::templates::container_spec;
 use hawkeye_core::models::{Status, Watcher};
 use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{ConfigMap, Pod, Service};
@@ -91,6 +92,81 @@ pub async fn create_watcher(
         reply::json(&watcher),
         StatusCode::CREATED,
     ))
+}
+
+pub async fn update_watcher(id: String, client: Client) -> Result<impl warp::Reply, Infallible> {
+    log::debug!("v1.update_watcher: {}", id);
+    let deployments: Api<Deployment> = Api::namespaced(client.clone(), &NAMESPACE);
+    let deployment = match deployments.get(&templates::deployment_name(&id)).await {
+        Ok(d) => d,
+        Err(_) => {
+            return Ok(reply::with_status(
+                reply::json(&json!({})),
+                StatusCode::NOT_FOUND,
+            ))
+        }
+    };
+
+    // We use the ConfigMap as source of truth for what are the watchers we have
+    let config_maps_client: Api<ConfigMap> = Api::namespaced(client.clone(), &NAMESPACE);
+    let config_map = match config_maps_client
+        .get(&templates::configmap_name(&id))
+        .await
+    {
+        Ok(c) => c,
+        Err(_) => {
+            return Ok(reply::with_status(
+                reply::json(&json!({})),
+                StatusCode::NOT_FOUND,
+            ))
+        }
+    };
+
+    let mut watcher: Watcher =
+        serde_json::from_str(config_map.data.unwrap().get("watcher.json").unwrap()).unwrap();
+    let watcher_status = deployment.get_watcher_status();
+    if watcher_status != Status::Ready {
+        return Ok(reply::with_status(
+            reply::json(
+                &json!({"message": "The Watcher must be stopped before the upgrade can be applied"}),
+            ),
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+    watcher.status = Some(watcher_status);
+
+    let patch_params = PatchParams::default();
+    let spec_updated = json!({
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [
+                        container_spec(&id, watcher.source.ingest_port)
+                    ]
+                }
+            }
+        }
+    });
+
+    match deployments
+        .patch(
+            deployment.metadata.name.as_ref().unwrap(),
+            &patch_params,
+            serde_json::to_vec(&spec_updated).unwrap(),
+        )
+        .await
+    {
+        Ok(_) => Ok(reply::with_status(reply::json(&watcher), StatusCode::OK)),
+        Err(e) => {
+            let msg: String = format!("Error while calling Kubernetes API: {:?}", e);
+            log::error!("{}", msg);
+            let error_body = json!({ "message": msg });
+            return Ok(reply::with_status(
+                reply::json(&error_body),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ));
+        }
+    }
 }
 
 pub async fn get_watcher(id: String, client: Client) -> Result<impl warp::Reply, Infallible> {


### PR DESCRIPTION
We will need to update the Watcher K8s Deployment definition whenever a new version of Hawkeye is released.

Hawkeye worker is packaged in a Docker image and after the Watcher K8s Deployment is created there is currently no way of automatically upgrading the Hawkeye worker code behind the Watcher. Watchers created on version V1 currently can only be upgraded manually, by changing the docker image version in the K8s Deployment resource for that Watcher.

Whenever we deploy a new version of the Hawkeye we need to upgrade the Watchers one by one. A Hawkeye API endpoint to automate that kind of upgrade is essential. Each Watcher can have it's own window for upgrading the Hawkeye worker running version.

We don't want to recreate the Watcher, since the ingest URL will change and integrations pointing to that watcher will need to be updated.