### PR TITLE
Use same port of video content ingestion for the telemetry HTTP server

### DIFF
--- a/hawkeye-api/src/config.rs
+++ b/hawkeye-api/src/config.rs
@@ -3,9 +3,14 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use std::iter;
 
+// Environment variable names
 const NAMESPACE_ENV: &str = "HAWKEYE_NAMESPACE";
 const DOCKER_IMAGE_ENV: &str = "HAWKEYE_DOCKER_IMAGE";
 const FIXED_TOKEN_ENV: &str = "HAWKEYE_FIXED_TOKEN";
+const CALL_WATCHER_TIMEOUT_ENV: &str = "HAWKEYE_CALL_WATCHER_TIMEOUT_TOKEN";
+
+// Configuration defaults
+const DEFAULT_CALL_WATCHER_TIMEOUT: u32 = 2;
 
 lazy_static! {
     /// Kubernetes namespace where the resources are managed (created/deleted/updated)
@@ -19,6 +24,10 @@ lazy_static! {
     /// A fixed authentication token required by clients while calling the Hawkeye API
     pub static ref FIXED_TOKEN: String =
         std::env::var(FIXED_TOKEN_ENV).unwrap_or_else(|_| gen_token());
+
+    pub static ref CALL_WATCHER_TIMEOUT: u32 =
+        std::env::var(CALL_WATCHER_TIMEOUT_ENV).map(|val| val.parse::<u32>()).unwrap_or_else(|_| Ok(DEFAULT_CALL_WATCHER_TIMEOUT)).unwrap_or(DEFAULT_CALL_WATCHER_TIMEOUT);
+
 }
 
 /// In case the environment variable `HAWKEYE_FIXED_TOKEN` is not present, a

--- a/hawkeye-api/src/config.rs
+++ b/hawkeye-api/src/config.rs
@@ -10,7 +10,7 @@ const FIXED_TOKEN_ENV: &str = "HAWKEYE_FIXED_TOKEN";
 const CALL_WATCHER_TIMEOUT_ENV: &str = "HAWKEYE_CALL_WATCHER_TIMEOUT_TOKEN";
 
 // Configuration defaults
-const DEFAULT_CALL_WATCHER_TIMEOUT: u32 = 2;
+const DEFAULT_CALL_WATCHER_TIMEOUT: u64 = 2;
 
 lazy_static! {
     /// Kubernetes namespace where the resources are managed (created/deleted/updated)
@@ -25,8 +25,8 @@ lazy_static! {
     pub static ref FIXED_TOKEN: String =
         std::env::var(FIXED_TOKEN_ENV).unwrap_or_else(|_| gen_token());
 
-    pub static ref CALL_WATCHER_TIMEOUT: u32 =
-        std::env::var(CALL_WATCHER_TIMEOUT_ENV).map(|val| val.parse::<u32>()).unwrap_or_else(|_| Ok(DEFAULT_CALL_WATCHER_TIMEOUT)).unwrap_or(DEFAULT_CALL_WATCHER_TIMEOUT);
+    pub static ref CALL_WATCHER_TIMEOUT: u64 =
+        std::env::var(CALL_WATCHER_TIMEOUT_ENV).map(|val| val.parse::<u64>()).unwrap_or_else(|_| Ok(DEFAULT_CALL_WATCHER_TIMEOUT)).unwrap_or(DEFAULT_CALL_WATCHER_TIMEOUT);
 
 }
 

--- a/hawkeye-api/src/handlers.rs
+++ b/hawkeye-api/src/handlers.rs
@@ -9,6 +9,7 @@ use kube::{Api, Client};
 use serde_json::json;
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::time::Duration;
 use uuid::Uuid;
 use warp::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use warp::http::{HeaderValue, StatusCode};
@@ -262,6 +263,23 @@ pub async fn get_watcher(id: String, client: Client) -> Result<impl warp::Reply,
 
 pub async fn get_video_frame(id: String, client: Client) -> Result<impl warp::Reply, Infallible> {
     let mut resp = warp::reply::Response::new(Body::empty());
+
+    // We use the ConfigMap as source of truth for what are the watchers we have
+    let config_maps_client: Api<ConfigMap> = Api::namespaced(client.clone(), &NAMESPACE);
+    let config_map = match config_maps_client
+        .get(&templates::configmap_name(&id))
+        .await
+    {
+        Ok(c) => c,
+        Err(_) => {
+            log::debug!("ConfigMap object not found for this watcher: {}", id);
+            *resp.status_mut() = StatusCode::NOT_FOUND;
+            return Ok(resp);
+        }
+    };
+    let watcher: Watcher =
+        serde_json::from_str(config_map.data.unwrap().get("watcher.json").unwrap()).unwrap();
+
     let deployments_client: Api<Deployment> = Api::namespaced(client.clone(), &NAMESPACE);
     let deployment = match deployments_client
         .get(&templates::deployment_name(&id))
@@ -289,25 +307,36 @@ pub async fn get_video_frame(id: String, client: Client) -> Result<impl warp::Re
         .map(|ps| ps.pod_ip.clone())
         .flatten()
     {
-        let url = format!(
-            "http://{}:{}/latest_frame",
-            pod_ip,
-            templates::deployment_metrics_port()
-        );
-        log::debug!("Calling Pod using url: {}", url);
-        match reqwest::get(url.as_str()).await.unwrap().error_for_status() {
-            Ok(image_response) => {
-                let image_bytes = image_response.bytes().await.unwrap();
-                let headers = resp.headers_mut();
-                headers.insert(CONTENT_TYPE, HeaderValue::from_static("image/png"));
-                headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
-                *resp.body_mut() = Body::from(image_bytes);
-            }
-            Err(err) => {
-                log::error!("Error calling PodIP: {:?}", err);
-                *resp.status_mut() = StatusCode::EXPECTATION_FAILED;
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+        // Try for new and old ports in pod
+        for port in vec![watcher.source.ingest_port, 3030] {
+            let url = format!("http://{}:{}/latest_frame", pod_ip, port);
+            log::info!("Calling Pod using url: {}", url);
+            match http_client
+                .get(url.as_str())
+                .send()
+                .await
+                .unwrap()
+                .error_for_status()
+            {
+                Ok(image_response) => {
+                    let image_bytes = image_response.bytes().await.unwrap();
+                    let headers = resp.headers_mut();
+                    headers.insert(CONTENT_TYPE, HeaderValue::from_static("image/png"));
+                    headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+                    *resp.body_mut() = Body::from(image_bytes);
+                    return Ok(resp);
+                }
+                Err(_) => {
+                    continue;
+                }
             }
         }
+        log::error!("Error calling Pod using old and new urls");
+        *resp.status_mut() = StatusCode::EXPECTATION_FAILED;
     } else {
         log::debug!("Not able to get Pod IP");
         *resp.status_mut() = StatusCode::EXPECTATION_FAILED;

--- a/hawkeye-api/src/handlers.rs
+++ b/hawkeye-api/src/handlers.rs
@@ -1,4 +1,4 @@
-use crate::config::NAMESPACE;
+use crate::config::{NAMESPACE, CALL_WATCHER_TIMEOUT};
 use crate::templates;
 use crate::templates::container_spec;
 use hawkeye_core::models::{Status, Watcher};
@@ -308,7 +308,7 @@ pub async fn get_video_frame(id: String, client: Client) -> Result<impl warp::Re
         .flatten()
     {
         let http_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(2))
+            .timeout(Duration::from_secs(*CALL_WATCHER_TIMEOUT))
             .build()
             .unwrap();
         // Try for new and old ports in pod

--- a/hawkeye-api/src/templates.rs
+++ b/hawkeye-api/src/templates.rs
@@ -34,14 +34,9 @@ pub fn deployment_name(watcher_id: &str) -> String {
     format!("hawkeye-deploy-{}", watcher_id)
 }
 
-/// General reference to the deployment Pod metrics server
-pub fn deployment_metrics_port() -> u32 {
-    3030
-}
-
 /// Builds a `Deployment` configured to run the hawkeye-worker process.
 pub fn build_deployment(watcher_id: &str, ingest_port: u32) -> Deployment {
-    let metric_port_str = deployment_metrics_port().to_string();
+    let metric_port_str = ingest_port.to_string();
     serde_json::from_value(json!({
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -127,7 +122,7 @@ pub fn container_spec(watcher_id: &str, ingest_port: u32) -> serde_json::Value {
         "resources": {
             "limits": {
                 "cpu": "2000m",
-                "memory": "70Mi"
+                "memory": "100Mi"
             },
             "requests": {
                 "cpu": "1150m",
@@ -140,7 +135,7 @@ pub fn container_spec(watcher_id: &str, ingest_port: u32) -> serde_json::Value {
                 "protocol": "UDP"
             },
             {
-                "containerPort": deployment_metrics_port(),
+                "containerPort": ingest_port,
                 "protocol": "TCP"
             }
         ],

--- a/hawkeye-worker/src/main.rs
+++ b/hawkeye-worker/src/main.rs
@@ -57,7 +57,8 @@ fn main() -> Result<()> {
     });
 
     // starts metrics web app
-    thread::spawn(run_metrics_service);
+    let metrics_port = watcher.source.ingest_port as u16;
+    thread::spawn(move || run_metrics_service(metrics_port));
 
     let running = Arc::new(AtomicBool::new(true));
 

--- a/hawkeye-worker/src/metrics.rs
+++ b/hawkeye-worker/src/metrics.rs
@@ -98,7 +98,7 @@ fn latest_frame() -> impl warp::Reply {
     Ok(response)
 }
 
-pub fn run_metrics_service() {
+pub fn run_metrics_service(metrics_port: u16) {
     let mut runtime = Builder::new()
         .threaded_scheduler()
         .thread_name("metrics_app")
@@ -111,5 +111,5 @@ pub fn run_metrics_service() {
             .map(get_metric_contents)
             .or(warp::path("latest_frame").map(latest_frame)),
     );
-    runtime.block_on(warp::serve(routes).run(([0, 0, 0, 0], 3030)));
+    runtime.block_on(warp::serve(routes).run(([0, 0, 0, 0], metrics_port)));
 }


### PR DESCRIPTION
AWS Load balancers in UDP mode expects the service to respond to health checks using TCP in the same port where the UDP service is exposed.

> For a UDP service, target availability can be tested using non-UDP health checks on your target group. 

https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html

This is causing an issue where the load balancers created by the Hawkeye service are marked as unhealthy. Sometimes the load balancer will not forward the content to the target group. It is not clear why some load balancers still forward content when the target group is unhealthy. I suspect it can forward if content is sent right after the load balancer is created. But if the load balancer is created and several minutes later we start sending content, the target groups are already marked as unhealthy, the load balancer will not forward the video content. 

This PR makes the Hawkeye Worker use the same ingest port for the HTTP telemetry service that expose metrics and the latest video frame captured. Since the GStreamer pipeline and the HTTP server are running in the same process we have no problem in binding both sockets to the same port. The content is not mixed since they use different network protocols.

We expect that after this PR the target groups of the AWS Load balancers get marked as healthy and the content to be forward without problems to the Hawkeye Workers.